### PR TITLE
Fix overnight prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: 🟧 Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
       - name: 🟧 Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
       - name: 🟧 Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]

--- a/dist/index.js
+++ b/dist/index.js
@@ -11140,10 +11140,29 @@ async function main() {
     if (isPreRelease) {
         debug(`pre-release: ${latest.clean}`);
         let preRelease = semver_1.default.prerelease(latest.clean);
-        if (preRelease && preRelease.join(".") === "pre.0") {
+        if (!preRelease || typeof preRelease[1] !== "number") {
+            core.error("Unable to parse prerelease");
+            throw new Error("Unable to parse prerelease");
+        }
+        if (preRelease.join(".") === "pre.0") {
+            // pre.0 - compare against the prior stable release
             debug(`first pre-release: ${latest.clean}`);
             let stableTags = getStableTags(gitTags);
             previous = stableTags[0];
+        }
+        else {
+            // >=pre.1 - compare against the prior prerelease
+            let priorTag = latest.raw.replace(preRelease.join("."), [preRelease[0], preRelease[1] - 1].join(".") // pre.N-1`
+            );
+            debug(`looking for prior prerelease tag: ${priorTag}`);
+            let priorPreRelease = gitTags.find((tag) => tag.raw === priorTag);
+            if (priorPreRelease) {
+                previous = priorPreRelease;
+            }
+            else {
+                core.error("Unable to find the prior prerelease, exiting...");
+                throw new Error("Unable to find the prior prerelease, exiting...");
+            }
         }
     }
     else if (isStable) {


### PR DESCRIPTION
Replaces https://github.com/remix-run/release-comment-action/pull/32

This fixes an issue with `pre.N` (where N > 0) prereleases that happen the next day because there has since been a nightly release so the current code compares against the nightly otag as the "prior" instead of the prior prerelease from the previous day.

Here's an [example](https://github.com/remix-run/react-router/actions/runs/16809709369/job/47611755116) of this happening in React Router:

<img width="1728" height="444" alt="Screenshot 2025-08-08 at 11 16 29 AM" src="https://github.com/user-attachments/assets/a6ecafb7-9318-4197-b5e8-314edef708dc" />
